### PR TITLE
Fix incomplete macOS M1 architecture detection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -219,7 +219,7 @@ class Openrndr {
     } else when (OperatingSystem.current()) {
         OperatingSystem.WINDOWS -> "windows"
         OperatingSystem.MAC_OS -> when (val h = DefaultNativePlatform("current").architecture.name) {
-            "arm-v8" -> "macos-arm64"
+            "aarch64", "arm-v8" -> "macos-arm64"
             else -> "macos"
         }
         OperatingSystem.LINUX -> when (val h = DefaultNativePlatform("current").architecture.name) {


### PR DESCRIPTION
When trying to run the example projects on an M1 Mac I run into the following error on starting the basic drawing app (C100_DrawingPrimitives000.kt):

```
[LWJGL] Platform/architecture mismatch detected for module: org.lwjgl
	JVM platform:
		macOS aarch64 17.0.4
		Java HotSpot(TM) 64-Bit Server VM v17.0.4+11-LTS-179 by Oracle Corporation
	Platform available on classpath:
		macos/x64
```

I found [this PR](https://github.com/openrndr/openrndr-template/pull/31) that seems to solve this for the basic template, it would be nice to include it in the examples too for the next M1 user not to run into it.